### PR TITLE
404 page

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+
+  <article>
+    <h1>Page not found! - 404</h1>
+    <p>Sorry but the link you used is not working, please try again or take a look at our <a href="/posts">posts archive</a>.</p>
+
+    {{ partial "github.html" . }}
+  </article>
+
+{{ end }}


### PR DESCRIPTION
Fixes #11

Adds a 404 page that renders at `/404.html`. ~~A setting at Netlify will also be added to configure the default redirect for any unknown url~~ It will be [automatically picked up](https://docs.netlify.com/routing/redirects/redirect-options/?#custom-404-page-handling). 
